### PR TITLE
Replace unittest-mock dependency with pytest-mock

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest
 flake8
 black
-unittest-mock
+pytest-mock


### PR DESCRIPTION
## Summary
- fix dev requirements by replacing invalid `unittest-mock` with `pytest-mock`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: AssertionError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6898bd884f3c832fb8eb8cd42be717dc