### PR TITLE
Implement connection check for Jupyter

### DIFF
--- a/jupyter_utils.py
+++ b/jupyter_utils.py
@@ -1,46 +1,43 @@
+import requests
+
+
 def start_remote_jupyter_server(remote_host, remote_port):
-  """
-  Simulates starting a Jupyter server on the remote machine.
+    """Simulates starting a Jupyter server on the remote machine."""
+    print(f"Simulating starting Jupyter server on {remote_host} at port {remote_port}")
+    # In a real scenario, you would execute the shell command here
+    # For simulation purposes, we simply log the action.
 
-  Args:
-    remote_host: The hostname or IP address of the remote machine.
-    remote_port: The port number to use for the Jupyter server.
-
-  This function would typically execute a shell command like:
-  jupyter notebook --no-browser --port=<remote_port>
-  """
-  print(f"Simulating starting Jupyter server on {remote_host} at port {remote_port}")
-  # In a real scenario, you would execute the shell command here
-  pass
 
 def create_ssh_tunnel(local_port, remote_port, username, remote_host):
-  """
-  Simulates creating an SSH tunnel to the remote Jupyter server.
+    """Simulates creating an SSH tunnel to the remote Jupyter server."""
+    print(
+        "Simulating creating SSH tunnel from local port "
+        f"{local_port} to {remote_host}:{remote_port} with user {username}"
+    )
+    # In a real scenario, you would execute the shell command here
+    # For simulation purposes, we simply log the action.
 
-  Args:
-    local_port: The local port number to use for the tunnel.
-    remote_port: The remote port number of the Jupyter server.
-    username: Your username on the remote machine.
-    remote_host: The hostname or IP address of the remote machine.
 
-  This function would typically execute a shell command like:
-  ssh -N -L <local_port>:localhost:<remote_port> <username>@<remote_host>
-  """
-  print(f"Simulating creating SSH tunnel from local port {local_port} to {remote_host}:{remote_port} with user {username}")
-  # In a real scenario, you would execute the shell command here
-  pass
+def verify_jupyter_connection(local_port, timeout=5):
+    """Verifies the connection to the Jupyter server through the local port.
 
-def verify_jupyter_connection(local_port):
-  """
-  Simulates verifying the connection to the Jupyter server through the local port.
+    The previous implementation always returned ``True`` regardless of whether
+    the server was reachable, which made it impossible to detect connection
+    issues.  This function now attempts to make an HTTP request to the Jupyter
+    server and returns ``True`` only when the request succeeds.
 
-  Args:
-    local_port: The local port number of the SSH tunnel.
+    Args:
+        local_port: The local port number of the SSH tunnel.
+        timeout: Number of seconds to wait for a response.
 
-  This function would typically attempt to access a specific URL like:
-  http://localhost:<local_port>
-  and check for a successful response.
-  """
-  print(f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}")
-  # In a real scenario, you would attempt to connect to the URL here
-  return True # Simulate a successful connection
+    Returns:
+        bool: ``True`` if the server responds with HTTP 200, ``False``
+        otherwise.
+    """
+    url = f"http://localhost:{local_port}"
+    print(f"Simulating verifying connection to Jupyter server at {url}")
+    try:
+        response = requests.get(url, timeout=timeout)
+        return response.status_code == 200
+    except requests.RequestException:
+        return False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest
 flake8
 black
 unittest-mock
+requests

--- a/test_jupyter_utils.py
+++ b/test_jupyter_utils.py
@@ -1,18 +1,8 @@
-
 import unittest
 from unittest.mock import patch, MagicMock
-import sys
+import requests
 
-# Add /content/ to the Python path within the test file itself
-sys.path.append('/content/')
-
-# Assume jupyter_utils.py is in the /content/ directory
-# In a real scenario, you would ensure this module is discoverable
-try:
-    from jupyter_utils import start_remote_jupyter_server, create_ssh_tunnel, verify_jupyter_connection
-except ImportError:
-    print("Error: Could not import jupyter_utils. Is jupyter_utils.py in /content/?")
-    sys.exit(1)
+import jupyter_utils
 
 
 class TestJupyterUtilsFunctions(unittest.TestCase):
@@ -21,110 +11,134 @@ class TestJupyterUtilsFunctions(unittest.TestCase):
         # Add print statements to see which tests are running
         print(f"\nRunning test: {self._testMethodName}")
 
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.print")
     def test_start_remote_jupyter_server_success(self, mock_print):
         remote_host = "remote.example.com"
         remote_port = 8888
-        start_remote_jupyter_server(remote_host, remote_port)
-        mock_print.assert_called_with(f"Simulating starting Jupyter server on {remote_host} at port {remote_port}")
+        jupyter_utils.start_remote_jupyter_server(remote_host, remote_port)
+        mock_print.assert_called_with(
+            f"Simulating starting Jupyter server on {remote_host} at port {remote_port}"
+        )
 
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.print")
     def test_start_remote_jupyter_server_different_port_success(self, mock_print):
         remote_host = "another.host.org"
         remote_port = 9999
-        start_remote_jupyter_server(remote_host, remote_port)
-        mock_print.assert_called_with(f"Simulating starting Jupyter server on {remote_host} at port {remote_port}")
+        jupyter_utils.start_remote_jupyter_server(remote_host, remote_port)
+        mock_print.assert_called_with(
+            f"Simulating starting Jupyter server on {remote_host} at port {remote_port}"
+        )
 
-    @patch('jupyter_utils.start_remote_jupyter_server', side_effect=Exception("Failed to start server"))
-    @patch('jupyter_utils.print')
+    @patch(
+        "jupyter_utils.start_remote_jupyter_server",
+        side_effect=Exception("Failed to start server"),
+    )
+    @patch("jupyter_utils.print")
     def test_start_remote_jupyter_server_failure(self, mock_print, mock_start):
         remote_host = "remote.example.com"
         remote_port = 8888
         with self.assertRaises(Exception) as context:
-            start_remote_jupyter_server(remote_host, remote_port)
+            jupyter_utils.start_remote_jupyter_server(remote_host, remote_port)
         self.assertTrue("Failed to start server" in str(context.exception))
         mock_start.assert_called_once_with(remote_host, remote_port)
         # The original function's print is not called when the mock raises an exception
         mock_print.assert_not_called()
 
-
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.print")
     def test_create_ssh_tunnel_success(self, mock_print):
         local_port = 8000
         remote_port = 8888
         username = "testuser"
         remote_host = "remote.example.com"
-        create_ssh_tunnel(local_port, remote_port, username, remote_host)
-        mock_print.assert_called_with(f"Simulating creating SSH tunnel from local port {local_port} to {remote_host}:{remote_port} with user {username}")
+        jupyter_utils.create_ssh_tunnel(local_port, remote_port, username, remote_host)
+        mock_print.assert_called_with(
+            f"Simulating creating SSH tunnel from local port {local_port} to {remote_host}:{remote_port} with user {username}"
+        )
 
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.print")
     def test_create_ssh_tunnel_different_ports_and_user_success(self, mock_print):
         local_port = 8080
         remote_port = 8889
         username = "anotheruser"
         remote_host = "another.host.org"
-        create_ssh_tunnel(local_port, remote_port, username, remote_host)
-        mock_print.assert_called_with(f"Simulating creating SSH tunnel from local port {local_port} to {remote_host}:{remote_port} with user {username}")
+        jupyter_utils.create_ssh_tunnel(local_port, remote_port, username, remote_host)
+        mock_print.assert_called_with(
+            f"Simulating creating SSH tunnel from local port {local_port} to {remote_host}:{remote_port} with user {username}"
+        )
 
-    @patch('jupyter_utils.create_ssh_tunnel', side_effect=OSError("SSH command failed"))
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.create_ssh_tunnel", side_effect=OSError("SSH command failed"))
+    @patch("jupyter_utils.print")
     def test_create_ssh_tunnel_failure(self, mock_print, mock_tunnel):
         local_port = 8000
         remote_port = 8888
         username = "testuser"
         remote_host = "remote.example.com"
         with self.assertRaises(OSError) as context:
-             create_ssh_tunnel(local_port, remote_port, username, remote_host)
+            jupyter_utils.create_ssh_tunnel(
+                local_port, remote_port, username, remote_host
+            )
         self.assertTrue("SSH command failed" in str(context.exception))
-        mock_tunnel.assert_called_once_with(local_port, remote_port, username, remote_host)
-        mock_print.assert_not_called() # print should not be called if an exception is raised before it
+        mock_tunnel.assert_called_once_with(
+            local_port, remote_port, username, remote_host
+        )
+        mock_print.assert_not_called()  # print should not be called if an exception is raised before it
 
-
-    @patch('jupyter_utils.verify_jupyter_connection', return_value=True)
-    @patch('jupyter_utils.print')
-    def test_verify_jupyter_connection_success(self, mock_print, mock_verify):
+    @patch("jupyter_utils.requests.get")
+    @patch("jupyter_utils.print")
+    def test_verify_jupyter_connection_success(self, mock_print, mock_get):
         local_port = 8000
-        is_connected = verify_jupyter_connection(local_port)
-        mock_print.assert_called_with(f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}")
+        mock_get.return_value = MagicMock(status_code=200)
+        is_connected = jupyter_utils.verify_jupyter_connection(local_port)
+        mock_print.assert_called_with(
+            f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
+        )
         self.assertTrue(is_connected)
-        mock_verify.assert_called_once_with(local_port)
+        mock_get.assert_called_once_with(f"http://localhost:{local_port}", timeout=5)
 
-
-    @patch('jupyter_utils.verify_jupyter_connection', return_value=False)
-    @patch('jupyter_utils.print')
-    def test_verify_jupyter_connection_failure(self, mock_print, mock_verify):
+    @patch("jupyter_utils.requests.get", side_effect=requests.RequestException("error"))
+    @patch("jupyter_utils.print")
+    def test_verify_jupyter_connection_failure(self, mock_print, mock_get):
         local_port = 8000
-        is_connected = verify_jupyter_connection(local_port)
-        mock_print.assert_called_with(f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}")
+        is_connected = jupyter_utils.verify_jupyter_connection(local_port)
+        mock_print.assert_called_with(
+            f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
+        )
         self.assertFalse(is_connected)
-        mock_verify.assert_called_once_with(local_port)
+        mock_get.assert_called_once_with(f"http://localhost:{local_port}", timeout=5)
 
-    @patch('jupyter_utils.verify_jupyter_connection', side_effect=[True, False, True])
-    @patch('jupyter_utils.print')
-    def test_verify_jupyter_connection_multiple_attempts(self, mock_print, mock_verify):
+    @patch("jupyter_utils.requests.get")
+    @patch("jupyter_utils.print")
+    def test_verify_jupyter_connection_multiple_attempts(self, mock_print, mock_get):
         local_port = 8000
+        mock_get.side_effect = [
+            MagicMock(status_code=200),
+            requests.RequestException("error"),
+            MagicMock(status_code=200),
+        ]
 
         # First attempt: success
-        is_connected_1 = verify_jupyter_connection(local_port)
+        is_connected_1 = jupyter_utils.verify_jupyter_connection(local_port)
         self.assertTrue(is_connected_1)
-        mock_print.assert_any_call(f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}")
-
+        mock_print.assert_any_call(
+            f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
+        )
 
         # Second attempt: failure
-        is_connected_2 = verify_jupyter_connection(local_port)
+        is_connected_2 = jupyter_utils.verify_jupyter_connection(local_port)
         self.assertFalse(is_connected_2)
-        mock_print.assert_any_call(f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}")
-
+        mock_print.assert_any_call(
+            f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
+        )
 
         # Third attempt: success
-        is_connected_3 = verify_jupyter_connection(local_port)
+        is_connected_3 = jupyter_utils.verify_jupyter_connection(local_port)
         self.assertTrue(is_connected_3)
-        mock_print.assert_any_call(f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}")
+        mock_print.assert_any_call(
+            f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
+        )
+
+        self.assertEqual(mock_get.call_count, 3)
 
 
-        self.assertEqual(mock_verify.call_count, 3)
-        mock_verify.assert_any_call(local_port)
-
-
-if __name__ == '__main__':
-    unittest.main(argv=['first-arg-is-ignored'], exit=False)
+if __name__ == "__main__":
+    unittest.main(argv=["first-arg-is-ignored"], exit=False)


### PR DESCRIPTION
## Summary
- add real HTTP check in `verify_jupyter_connection` using requests
- refactor tests to patch `requests.get` and import module directly
- include `requests` in dev requirements

## Testing
- `pre-commit run --files jupyter_utils.py test_jupyter_utils.py requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b6f262d0832f8689e21ca1771f8f