### PR TITLE
Resolve test conflicts with main

### DIFF
--- a/test_jupyter_utils.py
+++ b/test_jupyter_utils.py
@@ -1,19 +1,8 @@
-
 import unittest
 from unittest.mock import patch, MagicMock
-import sys
 import requests
 
-# Add /content/ to the Python path within the test file itself
-sys.path.append('/content/')
-
-# Assume jupyter_utils.py is in the /content/ directory
-# In a real scenario, you would ensure this module is discoverable
-try:
-    from jupyter_utils import start_remote_jupyter_server, create_ssh_tunnel, verify_jupyter_connection
-except ImportError:
-    print("Error: Could not import jupyter_utils. Is jupyter_utils.py in /content/?")
-    sys.exit(1)
+import jupyter_utils
 
 
 class TestJupyterUtilsFunctions(unittest.TestCase):
@@ -22,72 +11,85 @@ class TestJupyterUtilsFunctions(unittest.TestCase):
         # Add print statements to see which tests are running
         print(f"\nRunning test: {self._testMethodName}")
 
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.print")
     def test_start_remote_jupyter_server_success(self, mock_print):
         remote_host = "remote.example.com"
         remote_port = 8888
-        start_remote_jupyter_server(remote_host, remote_port)
-        mock_print.assert_called_with(f"Simulating starting Jupyter server on {remote_host} at port {remote_port}")
+        jupyter_utils.start_remote_jupyter_server(remote_host, remote_port)
+        mock_print.assert_called_with(
+            f"Simulating starting Jupyter server on {remote_host} at port {remote_port}"
+        )
 
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.print")
     def test_start_remote_jupyter_server_different_port_success(self, mock_print):
         remote_host = "another.host.org"
         remote_port = 9999
-        start_remote_jupyter_server(remote_host, remote_port)
-        mock_print.assert_called_with(f"Simulating starting Jupyter server on {remote_host} at port {remote_port}")
+        jupyter_utils.start_remote_jupyter_server(remote_host, remote_port)
+        mock_print.assert_called_with(
+            f"Simulating starting Jupyter server on {remote_host} at port {remote_port}"
+        )
 
-    @patch('test_jupyter_utils.start_remote_jupyter_server', side_effect=Exception("Failed to start server"))
-    @patch('jupyter_utils.print')
+    @patch(
+        "jupyter_utils.start_remote_jupyter_server",
+        side_effect=Exception("Failed to start server"),
+    )
+    @patch("jupyter_utils.print")
     def test_start_remote_jupyter_server_failure(self, mock_print, mock_start):
         remote_host = "remote.example.com"
         remote_port = 8888
         with self.assertRaises(Exception) as context:
-            start_remote_jupyter_server(remote_host, remote_port)
+            jupyter_utils.start_remote_jupyter_server(remote_host, remote_port)
         self.assertTrue("Failed to start server" in str(context.exception))
         mock_start.assert_called_once_with(remote_host, remote_port)
         # The original function's print is not called when the mock raises an exception
         mock_print.assert_not_called()
 
-
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.print")
     def test_create_ssh_tunnel_success(self, mock_print):
         local_port = 8000
         remote_port = 8888
         username = "testuser"
         remote_host = "remote.example.com"
-        create_ssh_tunnel(local_port, remote_port, username, remote_host)
-        mock_print.assert_called_with(f"Simulating creating SSH tunnel from local port {local_port} to {remote_host}:{remote_port} with user {username}")
+        jupyter_utils.create_ssh_tunnel(local_port, remote_port, username, remote_host)
+        mock_print.assert_called_with(
+            f"Simulating creating SSH tunnel from local port {local_port} to {remote_host}:{remote_port} with user {username}"
+        )
 
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.print")
     def test_create_ssh_tunnel_different_ports_and_user_success(self, mock_print):
         local_port = 8080
         remote_port = 8889
         username = "anotheruser"
         remote_host = "another.host.org"
-        create_ssh_tunnel(local_port, remote_port, username, remote_host)
-        mock_print.assert_called_with(f"Simulating creating SSH tunnel from local port {local_port} to {remote_host}:{remote_port} with user {username}")
+        jupyter_utils.create_ssh_tunnel(local_port, remote_port, username, remote_host)
+        mock_print.assert_called_with(
+            f"Simulating creating SSH tunnel from local port {local_port} to {remote_host}:{remote_port} with user {username}"
+        )
 
-    @patch('test_jupyter_utils.create_ssh_tunnel', side_effect=OSError("SSH command failed"))
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.create_ssh_tunnel", side_effect=OSError("SSH command failed"))
+    @patch("jupyter_utils.print")
     def test_create_ssh_tunnel_failure(self, mock_print, mock_tunnel):
         local_port = 8000
         remote_port = 8888
         username = "testuser"
         remote_host = "remote.example.com"
         with self.assertRaises(OSError) as context:
-             create_ssh_tunnel(local_port, remote_port, username, remote_host)
+            jupyter_utils.create_ssh_tunnel(
+                local_port, remote_port, username, remote_host
+            )
         self.assertTrue("SSH command failed" in str(context.exception))
-        mock_tunnel.assert_called_once_with(local_port, remote_port, username, remote_host)
-        mock_print.assert_not_called() # print should not be called if an exception is raised before it
+        mock_tunnel.assert_called_once_with(
+            local_port, remote_port, username, remote_host
+        )
+        mock_print.assert_not_called()  # print should not be called if an exception is raised before it
 
-
-    @patch('jupyter_utils.requests.get')
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.requests.get")
+    @patch("jupyter_utils.print")
     def test_verify_jupyter_connection_success(self, mock_print, mock_get):
         local_port = 8000
         mock_get.return_value = MagicMock(status_code=200)
 
-        is_connected = verify_jupyter_connection(local_port)
+        is_connected = jupyter_utils.verify_jupyter_connection(local_port)
 
         mock_print.assert_called_with(
             f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
@@ -95,14 +97,13 @@ class TestJupyterUtilsFunctions(unittest.TestCase):
         mock_get.assert_called_once_with(f"http://localhost:{local_port}")
         self.assertTrue(is_connected)
 
-
-    @patch('jupyter_utils.requests.get')
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.requests.get")
+    @patch("jupyter_utils.print")
     def test_verify_jupyter_connection_failure(self, mock_print, mock_get):
         local_port = 8000
         mock_get.side_effect = requests.RequestException("Connection failed")
 
-        is_connected = verify_jupyter_connection(local_port)
+        is_connected = jupyter_utils.verify_jupyter_connection(local_port)
 
         mock_print.assert_called_with(
             f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
@@ -110,8 +111,8 @@ class TestJupyterUtilsFunctions(unittest.TestCase):
         mock_get.assert_called_once_with(f"http://localhost:{local_port}")
         self.assertFalse(is_connected)
 
-    @patch('jupyter_utils.requests.get')
-    @patch('jupyter_utils.print')
+    @patch("jupyter_utils.requests.get")
+    @patch("jupyter_utils.print")
     def test_verify_jupyter_connection_multiple_attempts(self, mock_print, mock_get):
         local_port = 8000
         mock_get.side_effect = [
@@ -121,21 +122,21 @@ class TestJupyterUtilsFunctions(unittest.TestCase):
         ]
 
         # First attempt: success
-        is_connected_1 = verify_jupyter_connection(local_port)
+        is_connected_1 = jupyter_utils.verify_jupyter_connection(local_port)
         self.assertTrue(is_connected_1)
         mock_print.assert_any_call(
             f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
         )
 
         # Second attempt: failure
-        is_connected_2 = verify_jupyter_connection(local_port)
+        is_connected_2 = jupyter_utils.verify_jupyter_connection(local_port)
         self.assertFalse(is_connected_2)
         mock_print.assert_any_call(
             f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
         )
 
         # Third attempt: success
-        is_connected_3 = verify_jupyter_connection(local_port)
+        is_connected_3 = jupyter_utils.verify_jupyter_connection(local_port)
         self.assertTrue(is_connected_3)
         mock_print.assert_any_call(
             f"Simulating verifying connection to Jupyter server at http://localhost:{local_port}"
@@ -145,5 +146,6 @@ class TestJupyterUtilsFunctions(unittest.TestCase):
         mock_get.assert_any_call(f"http://localhost:{local_port}")
 
 
-if __name__ == '__main__':
-    unittest.main(argv=['first-arg-is-ignored'], exit=False)
+if __name__ == "__main__":
+    unittest.main(argv=["first-arg-is-ignored"], exit=False)
+


### PR DESCRIPTION
## Summary
- integrate main's requests-based `verify_jupyter_connection` implementation
- clean up test suite by removing path hacks and patching module functions directly
- add `requests` dependency for development

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68994804ec88832fba51c931c70da01d